### PR TITLE
Let the run directory index itself

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "speccy",
   "description": "A guided spec-to-implementation pipeline: specification, adversarial critique, planning, build, and independent review. Bundles the speccy orchestrator and the plan-execution build skill.",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "author": {
     "name": "Aidan Harding",
     "email": "aharding@aquiva.com"

--- a/skills/speccy/DECISION_LOG.md
+++ b/skills/speccy/DECISION_LOG.md
@@ -546,3 +546,13 @@ The danger is that the outlet becomes the next dumping ground. So it admits thre
 `engagementQuestions` is not a precedent for adding more. It stores what speccy asked, which no artifact holds and no reader wants, and it went in by changing the skill.
 
 What genuinely doesn't persist — the user is mid-read, a precondition passed an hour ago — is left to die with the context. A resumed run re-checks or asks, which is cheaper than a durable note that goes stale.
+
+### The run directory is its own index (2026-08-18)
+
+Closing state.json's schema left a question behind: with no sanctioned place to record what a run produced, how does a resumed context find the spikes, the change notes, the earlier rounds? The tempting answer is a `files` array, and it is the same mistake in a new shape. Give each entry a description and it is `runNotes` again, one field down. Strip the description to `{path, status}` and it becomes a second copy of the directory that goes stale on every write the run makes. So a resumed context lists `.speccy/<run-id>/` instead, and state.json inventories nothing.
+
+That works because the filenames already carry the three things a reader needs. What a file is comes from its name, which is why every prompt in the pipeline is told where to write. Which files an obligation attaches to comes from the phase text: `deferred.md` and `spec-critique-skipped.md` are named in the wrap-up that must report them, and any future file with an obligation on it belongs in the phase text the same way, not in a schema field. What no longer applies comes from a prefix: a run that replaced its plan mid-flight invented a stale marker in the filename, which is now the stated convention, `SUPERSEDED-<original name>`. It groups in a listing, survives any tool, and needs no field to interpret it. Spike verdicts are excluded, since evidence about the world outlives the draft that asked for it.
+
+The one named field added is `decisionLogPath`. It earns a slot because the decision log is the only artefact outside the run directory, so the listing genuinely misses it, and because two named path fields already exist for exactly this. Worth saying that a run reaching for the field is not the argument for it: that is the pull the closed schema exists to stop, and it points at gaps that turn out to be imaginary as often as real. The listing gap is the argument.
+
+Nothing was added to `allowed-tools` for the listing. `ls` sits where `git commit` and `git checkout -b` already sit, approved by the auto-accept mode the skill asks for before the autonomous phases begin.

--- a/skills/speccy/SKILL.md
+++ b/skills/speccy/SKILL.md
@@ -65,6 +65,7 @@ Run state lives at `.speccy/<run-id>/state.json` and is written after every phas
   "phase": "spec-critique" | "planning" | "plan-critique" | "implementation" | "review" | "wrap-up" | "complete",
   "specPath": "specs/auth-refactor.md",
   "planPath": ".speccy/auth-refactor-20260609-1430/plan.md",
+  "decisionLogPath": "specs/auth-refactor-decision-log.md",
   "specCritiqueRounds": 1,
   "planCritiqueRounds": 0,
   "reviewRounds": 0,
@@ -91,6 +92,10 @@ What remains is genuinely transient: the user is mid-read, a precondition passed
 `adversaryModel` defaults to `"opus"`: the tier for every critique round and the review panel's judgment lenses (the suppressions and comment lenses run a tier below; see **Getting started**). If the user pinned a different adversary model, store that name here instead and use it for every critique round and review lens.
 
 On trigger, read `.speccy/.current-runid`, a pointer to the most recent run written when the run is created (see Phase 1c). If it exists, read that run's `state.json`; if `phase` is not `"complete"`, surface the run to the user and ask whether to resume or start fresh. To resume, read the artifacts state.json references (spec, plan, latest critique round) and continue from the recorded phase.
+
+state.json names the spec, plan, and decision log, and no other file. **List `.speccy/<run-id>/` to see what else the run produced** — earlier rounds, spikes, readability change notes, deferred findings — and read what the phase you are resuming into needs.
+
+**When an artifact is replaced, rename what reviewed it.** A re-plan leaves its critique rounds and readability change notes describing a draft that no longer exists, and a resumed context reading one cold will act on findings that no longer apply. Rename each to `SUPERSEDED-<original name>`, which groups them in a listing. They remain the run's history, and the wrap-up reads them for a reversal nobody logged, so rename rather than delete. A spike verdict is evidence about the world rather than a review of a draft, so it keeps its name.
 
 A resumed run skips the precondition checks, so if the recorded phase is anything past the spec interview, suggest auto-accept mode (shift+tab) first: the rest of the run is autonomous tool calls.
 
@@ -229,7 +234,7 @@ Save to `specs/<slug>.md`.
 
 Start `specs/<slug>-decision-log.md` next to it (see **The decision log runs with the run**). Open it with what the run is working from: the seed and how it was treated, and any decision already taken that the spec's Decisions & rationale cannot hold, such as a point where the seed was overruled. If the interview produced no such history, the file opens with the seed alone and stays short. Commit both.
 
-Generate a `runId`: lowercase kebab from the slug plus a `YYYYMMDD-HHmm` timestamp (e.g. `auth-refactor-20260609-1430`). Create `.speccy/<run-id>/` and ensure `.speccy/` is in `.gitignore`. Write the initial `state.json` (phase: `spec-critique`, with runId, slug, baseBranch, adversaryModel, builderModel, specPath). Also write the runId to `.speccy/.current-runid` (plain text, no newline needed) so a later session can find this run without globbing.
+Generate a `runId`: lowercase kebab from the slug plus a `YYYYMMDD-HHmm` timestamp (e.g. `auth-refactor-20260609-1430`). Create `.speccy/<run-id>/` and ensure `.speccy/` is in `.gitignore`. Write the initial `state.json` (phase: `spec-critique`, with runId, slug, baseBranch, adversaryModel, builderModel, specPath, decisionLogPath). Also write the runId to `.speccy/.current-runid` (plain text, no newline needed) so a later session can find this run without globbing.
 
 Tell the user about the directory: critique rounds, the plan, review notes, and run state will be saved there so they can open them in their editor rather than scrolling terminal output. Mention the path once here; don't repeat it at every save.
 


### PR DESCRIPTION
Closing state.json's schema (#8) left a question behind: with no sanctioned place to record what a run produced, how does a resumed context find the spikes, change notes, and earlier rounds? A `files` array is the same mistake in a new shape — give each entry a description and it is `runNotes` again, one field down. So a resumed run lists `.speccy/<run-id>/` instead.

- **List the run directory on resume.** state.json names the spec, plan, and decision log, and no other file.
- **`SUPERSEDED-<original name>`** is now a stated convention for the critique rounds and readability change notes belonging to a draft that has been replaced. Prefix rather than suffix, so they group in a listing and the original tail still matches a `*critique-round-*` pattern. Spike verdicts keep their names: evidence about the world outlives the draft that asked for it.
- **`decisionLogPath` joins the schema**, the one exception. The decision log is the only artefact outside the run directory, so a listing genuinely misses it, and two named path fields already exist for exactly this.

Nothing was added to `allowed-tools`: `ls` sits where `git commit` already sits, covered by the auto-accept mode the skill asks for before the autonomous phases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)