### PR TITLE
Set the spec's Status to Accepted when critique exits

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "speccy",
   "description": "A guided spec-to-implementation pipeline: specification, adversarial critique, planning, build, and independent review. Bundles the speccy orchestrator and the plan-execution build skill.",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "author": {
     "name": "Aidan Harding",
     "email": "aharding@aquiva.com"

--- a/skills/speccy/DECISION_LOG.md
+++ b/skills/speccy/DECISION_LOG.md
@@ -616,3 +616,9 @@ The orchestrator also reads git rather than the report. A batch can say it is do
 Effort is not a per-agent setting speccy can pin the way it pins models. Subagents inherit the session's, so a pipeline that spawns ninety of them multiplies whatever the session was started at, and a run at `xhigh` costs hours the user did not choose to spend. The other preconditions guard correctness; this one guards the clock, so it reports and proceeds rather than stopping.
 
 `CLAUDE_EFFORT` in the environment answers it, with `effortLevel` in `~/.claude/settings.json` as the fallback. The session transcript records `effort` per request too, and `metrics.mjs` already reads that field, but it was the wrong source: it needs the run's own transcript identified by mtime, and this repo has twice been caught by transcript-shape assumptions that returned believable wrong numbers. A silent value is left silent rather than assumed low, for the same reason the metrics report refuses to read an absent effort as a low one.
+
+### The spec's Status line is set on the way out of critique (2026-08-25)
+
+Every spec the pipeline produced said `Draft`: the template opened with that word and no later step wrote the field again, so a spec that had been through three adversarial rounds and a readability rewrite reached the planner still labelled a first draft. Deleting the field was the alternative, since one nobody maintains is worse than none. It stays because there is a real transition to record, and the critique loop's exit is it.
+
+The orchestrator writes it rather than an agent inside a round: no revise agent knows it is the last one. It is an exit check because that is what survives a resumed context. The readability pass gets one guard, since it is the step allowed to remove and a lone bold line under the title is what it would read as removable.

--- a/skills/speccy/SKILL.md
+++ b/skills/speccy/SKILL.md
@@ -270,9 +270,11 @@ For each round (up to 3):
 
 After 3 rounds, proceed regardless. Update state.json after each round (`specCritiqueRounds`).
 
+**When the loop exits, set the spec's Status to `Accepted`** and commit that line.
+
 **Exit checks.** Confirm each before leaving this phase (a resumed context has only what's on disk):
 
-- the revised spec is committed
+- the revised spec is committed, with **Status**: `Accepted`
 - `readabilityPasses` includes `"spec"`, and a critique round ran after it
 - the findings the user skipped, and any the 3-round cap left unaddressed, are in `.speccy/<run-id>/spec-critique-skipped.md` with the reason. The wrap-up reports them, and the `/clear` suggested just below deletes anything held only in conversation. Keep them out of `deferred.md`: the review panel is told not to re-raise anything in that file, and a skipped spec finding is a decision about the spec rather than acceptance of the matching defect in the code.
 - `phase` is `"planning"`

--- a/skills/speccy/prompts/readability-pass.md
+++ b/skills/speccy/prompts/readability-pass.md
@@ -15,7 +15,7 @@ Work through the artifact against those two standards:
 - **Hedges and asides.** Cut them. Uncertainty gets stated once, plainly, in the section that exists for it.
 - **Criteria.** In a spec, each completion criterion is one checkable line with no caveat. Move the qualification to Constraints or the doubt to Open questions; never drop it.
 
-**What you must not change:** any decision, deliverable, scope boundary, constraint, completion criterion, assumption, or open question. Don't add one, don't remove one, don't resolve an open question, don't soften a recorded risk, and don't reverse a decision because you find its reasoning thin. That judgement belongs to the critique loop and the user.
+**What you must not change:** the Status line under the title, or any decision, deliverable, scope boundary, constraint, completion criterion, assumption, or open question. Don't add one, don't remove one, don't resolve an open question, don't soften a recorded risk, and don't reverse a decision because you find its reasoning thin. That judgement belongs to the critique loop and the user.
 
 Losing a load-bearing fact is the one way this pass does damage, so every cut must be justifiable as one of three things: information that survives elsewhere in the file, process narrative, or a qualifier that carried no information. If you can't place a passage in one of those, keep it and shorten it instead.
 

--- a/skills/speccy/prompts/spec-template.md
+++ b/skills/speccy/prompts/spec-template.md
@@ -2,6 +2,8 @@
 
 **Status**: Draft
 
+<!-- `Draft` until the critique loop exits, then `Accepted`. The orchestrator sets it. -->
+
 <!-- Follow `writing-style.md`. The sections run description first, argument second, caveats last;
      keep them that way. Rationale belongs in Decisions & rationale rather than spread through the
      rest. Don't restate `CLAUDE.md` anywhere in this file. Reference it by file/section where a


### PR DESCRIPTION
Every spec the pipeline produced said `Draft`. The template opened with that word and no later step wrote the field again, so a spec that had been through three adversarial rounds and a readability rewrite reached the planner still labelled a first draft.

- `SKILL.md` (phase 1d): the orchestrator sets **Status** to `Accepted` when the spec critique loop exits, and the exit checks require it.
- `spec-template.md`: the field says what its two values mean and who sets it.
- `readability-pass.md`: the Status line joins the must-not-change list. That pass is the one step allowed to remove, and a lone bold line under the title is what it would read as removable.
- `DECISION_LOG.md`, and the plugin version bumped to 0.9.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)