### PR TITLE
Accept the spec where the user starts planning

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "speccy",
   "description": "A guided spec-to-implementation pipeline: specification, adversarial critique, planning, build, and independent review. Bundles the speccy orchestrator and the plan-execution build skill.",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "author": {
     "name": "Aidan Harding",
     "email": "aharding@aquiva.com"

--- a/skills/speccy/DECISION_LOG.md
+++ b/skills/speccy/DECISION_LOG.md
@@ -617,8 +617,10 @@ Effort is not a per-agent setting speccy can pin the way it pins models. Subagen
 
 `CLAUDE_EFFORT` in the environment answers it, with `effortLevel` in `~/.claude/settings.json` as the fallback. The session transcript records `effort` per request too, and `metrics.mjs` already reads that field, but it was the wrong source: it needs the run's own transcript identified by mtime, and this repo has twice been caught by transcript-shape assumptions that returned believable wrong numbers. A silent value is left silent rather than assumed low, for the same reason the metrics report refuses to read an absent effort as a low one.
 
-### The spec's Status line is set on the way out of critique (2026-08-25)
+### The spec's Status is set where the run starts building from the spec (2026-08-25)
 
-Every spec the pipeline produced said `Draft`: the template opened with that word and no later step wrote the field again, so a spec that had been through three adversarial rounds and a readability rewrite reached the planner still labelled a first draft. Deleting the field was the alternative, since one nobody maintains is worse than none. It stays because there is a real transition to record, and the critique loop's exit is it.
+Every spec the pipeline produced said `Draft`: the template opened with that word and no later step wrote the field again, so a spec that had been through three adversarial rounds and a readability rewrite reached the planner still labelled a first draft. Deleting the field was the alternative, since one nobody maintains is worse than none. It stays because there is a real transition to record.
 
-The orchestrator writes it rather than an agent inside a round: no revise agent knows it is the last one. It is an exit check because that is what survives a resumed context. The readability pass gets one guard, since it is the step allowed to remove and a lone bold line under the title is what it would read as removable.
+The write sits at the planner spawn rather than at the critique loop's exit. Leaving that loop can mean the 3-round cap ran out, which is not acceptance of anything. Planning starts on the user's say-so: the loop's exit is an offer to clear or move on, and they answer it by re-invoking at planning or asking to continue. So a spec that reaches the planner is one the user chose to build from, which is what the field records.
+
+An instruction at a phase's start is skippable in a way an exit check is not: a context resuming at `plan-critique` never passes the spawn. So the 2a exit checks carry the field as a backstop. The readability pass gets one guard too, since it is the step allowed to remove and a lone bold line under the title is what it would read as removable.

--- a/skills/speccy/SKILL.md
+++ b/skills/speccy/SKILL.md
@@ -270,11 +270,9 @@ For each round (up to 3):
 
 After 3 rounds, proceed regardless. Update state.json after each round (`specCritiqueRounds`).
 
-**When the loop exits, set the spec's Status to `Accepted`** and commit that line.
-
 **Exit checks.** Confirm each before leaving this phase (a resumed context has only what's on disk):
 
-- the revised spec is committed, with **Status**: `Accepted`
+- the revised spec is committed
 - `readabilityPasses` includes `"spec"`, and a critique round ran after it
 - the findings the user skipped, and any the 3-round cap left unaddressed, are in `.speccy/<run-id>/spec-critique-skipped.md` with the reason. The wrap-up reports them, and the `/clear` suggested just below deletes anything held only in conversation. Keep them out of `deferred.md`: the review panel is told not to re-raise anything in that file, and a skipped spec finding is a decision about the spec rather than acceptance of the matching defect in the code.
 - `phase` is `"planning"`
@@ -288,6 +286,8 @@ Before diving in, briefly orient the user on why planning is a separate step: th
 Planning research happens in a subagent to keep the codebase-reading noise out of the main context. Read `prompts/plan-research.md`.
 
 **Dispatch the project's own research agents from here rather than from the planner.** A spawned subagent is shown no agent types at all, so the planner cannot name a repo's own research agent, and a subagent that spawns children and waits on them has stalled twice. So if `.claude/agents/` holds read-only research agents, dispatch the relevant ones yourself before spawning the planner and pass their findings into its prompt. Cite them in the plan as research: unlike a house skill's rule, a research agent's answer is one agent's output, and the critique loop weighs it like any other evidence.
+
+**Set the spec's Status to `Accepted`** and commit that line before spawning the planner: entering planning is the user accepting the spec.
 
 Spawn a planning subagent (Agent tool) with the plan-research prompt, the spec path, the target plan path (`.speccy/<run-id>/plan.md`), the paths to `prompts/plan-template.md` and `prompts/writing-style.md`, and the path to `prompts/plan-spike.md` so the planner can prove any load-bearing mechanism (preferably by spawning a spike subagent, or inline). If the spec recorded external context (docs, standards, related projects), pass those references too. Read them from the spec rather than relying on conversation memory, since planning may run in a freshly cleared context.
 
@@ -311,8 +311,9 @@ For each round (up to 3):
 
 After 3 rounds, exit the loop regardless. Update state.json after each round (`planCritiqueRounds`). When the loop exits, surface a one-line note of how many rounds ran and what changed, then proceed to 2b.
 
-**Exit checks.** Confirm both before leaving this phase (a resumed context has only what's on disk):
+**Exit checks.** Confirm each before leaving this phase (a resumed context has only what's on disk):
 
+- the spec's **Status** is `Accepted`
 - the revised plan is committed
 - `readabilityPasses` includes `"plan"`, and a critique round ran after it
 

--- a/skills/speccy/prompts/spec-template.md
+++ b/skills/speccy/prompts/spec-template.md
@@ -2,7 +2,7 @@
 
 **Status**: Draft
 
-<!-- `Draft` until the critique loop exits, then `Accepted`. The orchestrator sets it. -->
+<!-- `Draft` until planning starts, then `Accepted`. The orchestrator sets it. -->
 
 <!-- Follow `writing-style.md`. The sections run description first, argument second, caveats last;
      keep them that way. Rationale belongs in Decisions & rationale rather than spread through the


### PR DESCRIPTION
Follow-up to #14, which set the spec's **Status** to `Accepted` when the spec critique loop exits. Leaving that loop can mean the 3-round cap ran out, which accepts nothing. Entering planning is the user's own act — the loop's exit is an offer to clear or move on, and they answer it by re-invoking at planning or asking to continue — so the write moves to just before the planner spawn.

- `SKILL.md`: the flip leaves 1d and lands immediately before the planning subagent is spawned.
- `SKILL.md` (2a exit checks): those carry the field as a backstop. An instruction at a phase's start is skippable where an exit check is not, and a context resuming at `plan-critique` never passes the spawn.
- `spec-template.md` and `DECISION_LOG.md` follow; plugin version bumped to 0.9.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)